### PR TITLE
Broadcast  a bxResize event on mouseup

### DIFF
--- a/boxy.js
+++ b/boxy.js
@@ -124,6 +124,7 @@
         function mouseup() {
             $document.unbind('mousemove', mousemove);
             $document.unbind('mouseup', mouseup);
+			$scope.$broadcast('bxResize');
         }
     };
 });


### PR DESCRIPTION
A resize event turned out to be necessary to fix an issue in Coda.